### PR TITLE
adjustment in phone translation rules

### DIFF
--- a/resources/asterisk/Magnus.php
+++ b/resources/asterisk/Magnus.php
@@ -634,23 +634,35 @@ class Magnus
             $number_prefix = substr($destination, 0, strlen($grab));
 
             if (strtoupper($this->config['global']['base_country']) == 'BRL' || strtoupper($this->config['global']['base_country']) == 'ARG') {
-                if ($grab == '*' && strlen($destination) == $digit) {
-                    $destination = $replace . $destination;
-                } else if (strlen($destination) == $digit && $number_prefix == $grab) {
-                    $destination = $replace . substr($destination, strlen($grab));
-                } elseif ($number_prefix == $grab) {
-                    $destination = $replace . substr($destination, strlen($grab));
-                }
+				if (strlen($destination) == $digit) {
+					if ($grab == '*') {
+						$destination = $replace . $destination;
+					} else if ($number_prefix == $grab) {
+						$destination = $replace . substr($destination, strlen($grab));
+					}
+				} elseif ($digit == '') {
+					if ($grab == '*') {
+						$destination = $replace . $destination;
+				    } elseif ($number_prefix == $grab) {
+						$destination = $replace . substr($destination, strlen($grab));
+					}
+				}
 
             } else {
 
                 if (strlen($destination) == $digit) {
-                    if ($grab == '*' && strlen($destination) == $digit) {
-                        $destination = $replace . $destination;
-                    } else if ($number_prefix == $grab) {
-                        $destination = $replace . substr($destination, strlen($grab));
-                    }
-                }
+					if ($grab == '*') {
+						$destination = $replace . $destination;
+					} else if ($number_prefix == $grab) {
+						$destination = $replace . substr($destination, strlen($grab));
+					}
+				} elseif ($digit == '') {
+					if ($grab == '*') {
+						$destination = $replace . $destination;
+				    } elseif ($number_prefix == $grab) {
+						$destination = $replace . substr($destination, strlen($grab));
+					}
+				}
             }
         }
 


### PR DESCRIPTION
Da maneira como a verificação estava ele aplicava a tradução no telefone mesmo o número (quantidade) de dígitos não correspondendo ao informado na regra.

### PRIMEIRA VERIFICAÇÃO 
###  if ($grab == '*' && strlen($destination) == $digit) {  
se começar com qualquer digito e tiver a quantidade de dígitos informados na regra ele efetua a substituição.
### SEGUNDA VERIFICAÇÃO 
### else if (strlen($destination) == $digit && $number_prefix == $grab) {
se começar com o digito informado na regra e possuir a quantidade de dígitos informados na regra ele efetua a substituição.
### TERCEIRA VERIFICAÇÃO 
### elseif ($number_prefix == $grab) {
se começar com o digito informado na regra ele efetua a substituição. **Independente do número de dígitos ser igual ao informado na regra.**

### Alteração
Na alteração que fiz, primeiro ele verifica se o número de dígitos discados corresponde ao valor informado na regra:
- Caso positivo ele verifica as informações de prefixos para efetuar a tradução do número.
- Caso negativo ele verifica se não foi indicado uma quantidade de dígitos **( $digit == '' )** para a regra e então prossegue na verificação das informações de prefixos.
- Caso o número de dígitos tenha sido informado na regra mas não corresponda ao número de dígitos do telefone discado ele não faz nada. **Essa é a diferença para o código como ele estava antes.**