### PR TITLE
fix #325

### DIFF
--- a/resources/asterisk/AuthenticateAgi.php
+++ b/resources/asterisk/AuthenticateAgi.php
@@ -24,6 +24,7 @@ class AuthenticateAgi
     {
         $agi->verbose('AuthenticateUser ' . $MAGNUS->accountcode, 15);
         $authentication = false;
+        $force_playback = false;
 
         /* TRY WITH THE CALLERID AUTHENTICATION*/
         $authentication = AuthenticateAgi::callerIdAuthenticate($MAGNUS, $agi, $authentication);
@@ -44,12 +45,13 @@ class AuthenticateAgi
 
         if ($authentication == false || $MAGNUS->active != 1) {
             $prompt = "prepaid-auth-fail";
+            $force_playback = true;
         } else {
             $prompt = $MAGNUS->check_expirationdate_customer($agi);
         }
 
         if (strlen($prompt) > 0) {
-            $MAGNUS->executePlayAudio($prompt, $agi);
+            $MAGNUS->executePlayAudio($prompt, $agi, $force_playback);
             $MAGNUS->hangup($agi);
         }
 

--- a/resources/asterisk/Magnus.php
+++ b/resources/asterisk/Magnus.php
@@ -658,10 +658,10 @@ class Magnus
         return round($number, $PRECISION);
     }
 
-    public function executePlayAudio($prompt, $agi)
+    public function executePlayAudio($prompt, $agi, $force_playback = false)
     {
         if (strlen($prompt) > 0) {
-            if ($this->play_audio == 1) {
+            if ($this->play_audio == 1 || $force_playback) {
                 $agi->verbose($prompt, 3);
                 $agi->answer();
                 $agi->stream_file($prompt, '#');


### PR DESCRIPTION
## Status
READY

## Migrations
NO

## Description
Forces playback when the customer object is not available to set the play_audio variable.
