### PR TITLE
fix #331

### DIFF
--- a/resources/asterisk/CalcAgi.php
+++ b/resources/asterisk/CalcAgi.php
@@ -756,7 +756,15 @@ class CalcAgi
 
             $MAGNUS->startRecordCall($agi);
             try {
-                $MAGNUS->run_dial($agi, $dialstr, $MAGNUS->agiconfig['dialcommand_param']
+                $dial_param = $MAGNUS->agiconfig['dialcommand_param'];
+
+                if (!isset($dial_param) || trim($dial_param) === '')
+                {
+                    $dial_param = ',';
+                }
+                $dial_param = $dial_param . 'U(trunk_answer_handler)';
+
+                $MAGNUS->run_dial($agi, $dialstr, $dial_param
                     , $this->tariffObj[$k]['rc_directmedia'], $timeout);
             } catch (Exception $e) {
                 //
@@ -768,7 +776,15 @@ class CalcAgi
                 $this->dialstatus        = 'ANSWER';
             } else {
 
-                $answeredtime            = $agi->get_variable("ANSWEREDTIME");
+                $answeredtime            = $agi->get_variable("trunkanswertime");
+
+                if (!isset($answeredtime['data']) || trim($answeredtime['data']) === '') {
+                    //support for installations that do not have the trunk_answer_handler context in the dialplan
+                    $answeredtime = $agi->get_variable("ANSWEREDTIME");
+                } else {
+                    $answeredtime['data'] = time() - $answeredtime['data'];
+                }
+
                 $this->real_answeredtime = $this->answeredtime = $answeredtime['data'];
                 $dialstatus              = $agi->get_variable("DIALSTATUS");
                 $this->dialstatus        = $dialstatus['data'];

--- a/script/install.sh
+++ b/script/install.sh
@@ -561,6 +561,11 @@ exten => h,1,hangup()
 exten => 111,1,VoiceMailMain(${CHANNEL(peername)}@billing)
   same => n,Hangup()
 
+[trunk_answer_handler]
+;needed for accurate billing - https://github.com/magnussolution/magnusbilling6/issues/331
+exten => s,1,Set(MASTER_CHANNEL(trunkanswertime)=${EPOCH})
+exten => s,n,Return()
+
 ' > /etc/asterisk/extensions_magnus.conf
 
 echo "


### PR DESCRIPTION
## Status
READY

## Migrations
Requires the addition of the following to `extensions_magnus.conf `
```
[trunk_answer_handler]
exten => s,1,Set(MASTER_CHANNEL(trunkanswertime)=${EPOCH})
exten => s,n,Return()
```
If the dialplan is missing, the fix will not work, the ANSWEREDTIME will revert back to the previous value.