### PR TITLE
Fixing Load balancer & Search Tariff issue when using Tech Prefix

### DIFF
--- a/protected/views/signup/add.php
+++ b/protected/views/signup/add.php
@@ -101,10 +101,10 @@
 	<p class="hint"><?php echo Yii::t('yii', 'Enter your') . ' ' . Yii::t('yii', 'city') ?></p>
 </div>
 <div class="field">
-	<?php echo $form->labelEx($signup, Yii::t('yii', 'neighborhood')) ?>
+	<?php echo $form->labelEx($signup, Yii::t('yii', 'Neighborhood')) ?>
 	<?php echo $form->textField($signup, 'neighborhood', array('class' => 'input')) ?>
 	<?php echo $form->error($signup, 'neighborhood') ?>
-	<p class="hint"><?php echo Yii::t('yii', 'Enter your') . ' ' . Yii::t('yii', 'neighborhood') ?></p>
+	<p class="hint"><?php echo Yii::t('yii', 'Enter your') . ' ' . Yii::t('yii', 'Neighborhood') ?></p>
 </div>
 
 <?php if ($language == 'pt_BR'): ?>

--- a/resources/asterisk/SearchTariff.php
+++ b/resources/asterisk/SearchTariff.php
@@ -36,6 +36,10 @@ class SearchTariff
 
         $MAGNUS->prefixclause = substr($MAGNUS->prefixclause, 0, -3) . ")";
 
+        // Searching for the Tariff Limit
+        $tariff_limit = "SELECT tariff_limit FROM pkg_plan WHERE id=$MAGNUS->id_plan";
+        $limitresult = $agi->query($tariff_limit)->fetch(PDO::FETCH_ASSOC);
+        
         $sql = "SELECT lcrtype, pkg_plan.id AS id_plan, pkg_prefix.prefix AS dialprefix, " .
         "pkg_plan.name, pkg_rate.id_prefix, pkg_rate.id AS id_rate, minimal_time_charge, " .
         "rateinitial, initblock, billingblock, connectcharge, disconnectcharge disconnectcharge, " .
@@ -44,7 +48,7 @@ class SearchTariff
         "LEFT JOIN pkg_rate ON pkg_plan.id = pkg_rate.id_plan " .
         "LEFT JOIN pkg_prefix ON pkg_rate.id_prefix = pkg_prefix.id " .
         "WHERE pkg_plan.id=$MAGNUS->id_plan AND pkg_rate.status = 1 AND " . $MAGNUS->prefixclause .
-            "ORDER BY LENGTH( prefix ) DESC LIMIT $MAGNUS->tariff_limit";
+            "ORDER BY LENGTH( prefix ) DESC LIMIT " . $limitresult['tariff_limit'];
         $result = $agi->query($sql)->fetchAll(PDO::FETCH_ASSOC);
         // $agi->verbose($result, 25);
 
@@ -116,7 +120,7 @@ class SearchTariff
 
         if (isset($modelBalance->last_use)) {
             $ultimo = $modelBalance->last_use;
-            if ($modelBalance->last_use >= $total - 1) {
+            if ($modelBalance->last_use >= $total) {
                 $sql = "UPDATE pkg_balance SET last_use = 0 WHERE id_prefix = " . $result[0]['dialprefix'];
             } else {
                 $sql = "UPDATE pkg_balance SET last_use = last_use + 1 WHERE id_prefix = " . $result[0]['dialprefix'];

--- a/resources/locale/php/pt_BR/yii.php
+++ b/resources/locale/php/pt_BR/yii.php
@@ -274,6 +274,7 @@ return array(
     'Did Destination'                                                                                                                                                                  => 'Destino dos Dids',
     'Did Use'                                                                                                                                                                          => 'Uso dos Dids',
     'Did'                                                                                                                                                                              => 'Números Dids',
+    'Neighborhood'                                                                                                                                                                     => 'Bairro',
     'Disallowed action'                                                                                                                                                                => 'Não foi permitido executar esta ação',
     'Group User'                                                                                                                                                                       => 'Grupos de Usuários',
     'Moludes'                                                                                                                                                                          => 'Módulos',


### PR DESCRIPTION
- Fixed the issue of Load Balancer when assigning the User to different Plans and using Tech Prefix to route to the needed plan which has a Load Balancer set to YES.

- Fixed the issue when having multiple tariffs with the same prefix, it always using all tariffs of the same prefix except for the last tariff always left not used.

## Status
**READY**

## Description
I have around 5 Plans, each of them has multiple tariffs with the same prefix and with different prefixes, I noticed that when I assign a User to a certain plan, for example, *plan 1* - and I want him to use more than one plan, then I give him a Tech prefix for *plan 2*, then he dials to plan 2 while I'm using Load Balancer and I set the Search Tariff to the number of tariffs with the same prefix, it routes the call only to the first tariff, not the others, and after I fixed it - I found that it also doesn't use the last tariff, so for example, if I have 3 tariffs with the same prefix, it will use only 1 and 2 but will leave 3 not used.

## Steps to Test or Reproduce
1. Create 2 Plans, each one with a certain Tech Prefix.
2. Create a Client Account.
3. Assign the Client Account to *First Plan*.
4. Create multiple tariffs on *Second Plan* with same prefix and route them to different trunks.
5. Make multiple calls using the Client Account to *Second Plan* using the Tech Prefix.
6. Notice that it does route only to the first tariff.
