### PR TITLE
Modifying the status of a SIP account to show the client's IP address

### DIFF
--- a/protected/controllers/SipController.php
+++ b/protected/controllers/SipController.php
@@ -239,7 +239,7 @@ class SipController extends Controller
                     $attributes[$i]['lineStatus'] = $value['Status'];
 
                     if (preg_match('/OK/', $value['Status'])) {
-                        $attributes[$i]['lineStatus'] .= ' ' . $value['server'];
+                        $attributes[$i]['lineStatus'] .= ' ' . $value['Host'];
                         break;
                     }
                 }


### PR DESCRIPTION
Changes the STATUS information that is displayed for each SIP account:
BEFORE:
OK (22ms) localhost

AFTER:
OK (22ms) 200.201.180.174

shows the user's IP address instead of 'localhost'