### PR TITLE
[2] Correção de sintaxe para geração dos "call files" e ajuste do campo Extension - Call0800WebController.php 

### DIFF
--- a/protected/controllers/Call0800WebController.php
+++ b/protected/controllers/Call0800WebController.php
@@ -65,8 +65,8 @@ class Call0800WebController extends Controller
             $call .= "Context: billing\n";
             $call .= "Extension: " . $user . "\n";
             $call .= "Priority: 1\n";
-            $call .= "Set:IDUSER=" . $model->id_user . "\n";
-            $call .= "Set:SECCALL=" . $destination . "\n";
+            $call .= "Setvar:IDUSER=" . $model->id_user . "\n";
+            $call .= "Setvar:SECCALL=" . $destination . "\n";
 
             AsteriskAccess::generateCallFile($call);
 
@@ -204,17 +204,17 @@ class Call0800WebController extends Controller
                 $call .= "Context: billing\n";
                 $call .= "Extension: " . $yournumber . "\n";
                 $call .= "Priority: 1\n";
-                $call .= "Set:CALLED=" . $yournumber . "\n";
-                $call .= "Set:TARRIFID=" . $callTrunk[0]['id_rate'] . "\n";
-                $call .= "Set:SELLCOST=" . $callTrunk[0]['rateinitial'] . "\n";
-                $call .= "Set:BUYCOST=" . $callTrunk[0]['buyrate'] . "\n";
-                $call .= "Set:CIDCALLBACK=1\n";
-                $call .= "Set:IDUSER=" . $result[0]['id'] . "\n";
-                $call .= "Set:IDPREFIX=" . $callTrunk[0]['id_prefix'] . "\n";
-                $call .= "Set:IDTRUNK=" . $idTrunk . "\n";
-                $call .= "Set:IDPLAN=" . $result[0]['id_plan'] . "\n";
+                $call .= "Setvar:CALLED=" . $yournumber . "\n";
+                $call .= "Setvar:TARRIFID=" . $callTrunk[0]['id_rate'] . "\n";
+                $call .= "Setvar:SELLCOST=" . $callTrunk[0]['rateinitial'] . "\n";
+                $call .= "Setvar:BUYCOST=" . $callTrunk[0]['buyrate'] . "\n";
+                $call .= "Setvar:CIDCALLBACK=1\n";
+                $call .= "Setvar:IDUSER=" . $result[0]['id'] . "\n";
+                $call .= "Setvar:IDPREFIX=" . $callTrunk[0]['id_prefix'] . "\n";
+                $call .= "Setvar:IDTRUNK=" . $idTrunk . "\n";
+                $call .= "Setvar:IDPLAN=" . $result[0]['id_plan'] . "\n";
 
-                $call .= "Set:SECCALL=" . $destination . "\n";
+                $call .= "Setvar:SECCALL=" . $destination . "\n";
                 AsteriskAccess::generateCallFile($call, 5);
                 echo Yii::t('zii', 'CallBack Success');
             }

--- a/protected/controllers/Call0800WebController.php
+++ b/protected/controllers/Call0800WebController.php
@@ -63,7 +63,7 @@ class Call0800WebController extends Controller
             $call = "Channel: " . $dialstr . "\n";
             $call .= "Callerid: " . $model->callerid . "\n";
             $call .= "Context: billing\n";
-            $call .= "Extension: " . $user . "\n";
+            $call .= "Extension: " . $destination . "\n";
             $call .= "Priority: 1\n";
             $call .= "Setvar:IDUSER=" . $model->id_user . "\n";
             $call .= "Setvar:SECCALL=" . $destination . "\n";


### PR DESCRIPTION
Os "call files" gerados a partir deste modulo não estão sendo executados de maneira correta pois a sintaxe para setar variavel parece estar incorreta. Pelo menos aqui na minha versão do Asterisk 13.35.0 não funciona na sintaxe atual que está presente no código, apenas funciona quando eu altero para "Setvar" ao invés de "Set".

`Setvar: <var=value>`
`Setvar: lets you set one or more channel variables.`

Também sugiro a alteração do campo "Extension" para o valor $destination pois caso o nome do usuario não seja inteiramente numerico ele não será reconhecido nas regras do dialplan que só considera números e não será executado:

`exten => _[*0-9].,1,AGI("/var/www/html/mbilling/resources/asterisk/mbilling.php")`
