### PR TITLE
Update IvrAgi.php - DISCAR DIRETO CONTA SIP

### DIFF
--- a/resources/asterisk/IvrAgi.php
+++ b/resources/asterisk/IvrAgi.php
@@ -66,10 +66,10 @@ class IvrAgi
             $wait_time     = 3000;
 
             if ($modelIvr->direct_extension == 1) {
-                $sql            = "SELECT name FROM pkg_sip WHERE id_user = " . $MAGNUS->id_user . " AND name REGEXP '^[0-9]*$' ORDER BY LENGTH(name) DESC LIMIT 1";
+                $sql            = "SELECT alias FROM pkg_sip WHERE id_user = " . $MAGNUS->id_user . " AND alias REGEXP '^[0-9]*$' ORDER BY LENGTH(alias) DESC LIMIT 1";
                 $modelSipDirect = $agi->query($sql)->fetch(PDO::FETCH_OBJ);
-                if (isset($modelSipDirect->name)) {
-                    $digit_timeout       = strlen($modelSipDirect->name);
+                if (isset($modelSipDirect->alias)) {
+                    $digit_timeout       = strlen($modelSipDirect->alias);
                     $wait_time           = 6000;
                     $is_direct_extention = true;
                 }


### PR DESCRIPTION
Quando a opção de 'DISCAR DIRETO CONTA SIP' é habilitada na URA ela só funciona com o NOME da conta SIP e não com o ramal (ALIAS) em si, acredito que este não seja o comportamento esperado. 

Acredito que o esperado seja que o usuario digite o ramal interno com o qual deseja falar e não o nome da conta SIP, pois o nome da conta SIP pode não ter nenhuma relação com o ramal que é utilizado por aquela conta.