### PR TITLE
Preencher o campo CALLERID(name) com a informação passada pelo terminal SIP (softphone ou aparelho SIP)

### DIFF
--- a/resources/asterisk/mbilling.php
+++ b/resources/asterisk/mbilling.php
@@ -238,6 +238,10 @@ if ($MAGNUS->mode == 'standard') {
                     $MAGNUS->CallerID = $modelSipCallerID->alias;
                 }
             }
+            
+            if ($agi->request['agi_calleridname'] !== 'unknown' && !empty($agi->request['agi_calleridname'])) {
+                $agi->set_variable("CALLERID(name)",$agi->request['agi_calleridname']);
+            }
 
             $MAGNUS->destination = $MAGNUS->dnid = $MAGNUS->modelSip->name;
             $MAGNUS->mode        = 'call-sip';


### PR DESCRIPTION
Possibilita a identificação de uma chamada entre ramais através do `DISPLAY NAME` do terminal SIP.

Hoje não é possível exibir o nome de quem liga para outro ramal pois a variavel `CALLERID(name)` não é preenchida pela AGI, com isso sempre que um ramal liga para outro, independente de ter setado o `DISPLAY NAME` em seu terminal (softphone ou aparelho SIP), esse nome não é exibido para quem recebe a ligação, apenas o número é exibido.

Com essa alteração é possível que ao ligar para outro ramal (alias) da mesma accountcode o nome seja exibido para quem recebe a ligação.
