### PR TITLE
Correções de erros do envio de email SMTP com Office 365

### DIFF
--- a/protected/components/Mail.php
+++ b/protected/components/Mail.php
@@ -382,9 +382,14 @@ class Mail
         $mail->Username   = $smtp_username;
         $mail->Password   = $smtp_password;
         $mail->Port       = $smtp_port;
-        $mail->SetFrom($this->from_email, $this->from_name);
-        $mail->SetLanguage($this->language == 'pt_BR' ? 'br' : $this->language);
 
+        if ($smtp_host == 'smtp.office365.com') {
+            $mail->SetFrom($smtp_username, $this->from_name);
+        } else {
+            $mail->SetFrom($this->from_email, $this->from_name);
+        }
+
+        $mail->SetLanguage($this->language == 'pt_BR' ? 'br' : $this->language);
         $mail->Subject = mb_encode_mimeheader($this->title);
         $mail->AltBody = 'To view the message, please use an HTML compatible email viewer!';
         $mail->MsgHTML($this->message);

--- a/protected/extensions/phpmailer/class.smtp.php
+++ b/protected/extensions/phpmailer/class.smtp.php
@@ -194,7 +194,7 @@ class SMTP {
     }
 
     // Begin encrypted connection
-    if(!stream_socket_enable_crypto($this->smtp_conn, true, STREAM_CRYPTO_METHOD_TLS_CLIENT)) {
+    if(!stream_socket_enable_crypto($this->smtp_conn, true, STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT | STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT | STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT | STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT | STREAM_CRYPTO_METHOD_TLS_CLIENT )) {
       return false;
     }
 


### PR DESCRIPTION
Alterações testadas no Magnus versão 7.8.2.6

O Office365 a algumas semanas deixou de aceitar o tls 1.0 e 1.1, suportando somente 1.2 ou maior, com isso o Magnus parou de enviar e-mail por conta de uma configuração no phpmailer está definido de uma forma que não usa protocolos maiores. A alteração do comit 8d3796e corrige o erro da imagem a seguir

![image](https://user-images.githubusercontent.com/2151109/204676257-dbc7313c-a936-492b-858a-7782f0a01d27.png)



O Office 365 também por padrão não aceita que outro e-mail diferente do usuário autenticado seja informado no campo from, acredito que para este caso o ideal é ter um checkbox no configurador do SMTP para forçar o SetFrom ser o e-mail da autenticação e não o informado no Template. Como não sei fazer a inclusão deste campo, apenas amarrei no código que se form smtp.office365.com use o e-mail de autenticação em vez do e-mail do template.

Erro corrigido

![image](https://user-images.githubusercontent.com/2151109/204676593-c9cd3ca7-ee8f-4b2c-afa8-c68c00195a91.png)


