### PR TITLE
Fix: [Removes use of count() on result of find()

### DIFF
--- a/protected/controllers/MoipController.php
+++ b/protected/controllers/MoipController.php
@@ -23,7 +23,7 @@ class MoipController extends Controller
             if ($status_pagamento == 1) {
                 $modelUser = User::model()->find('username = :usuario', array(':usuario' => $usuario));
 
-                if (count($modelUser) && Refill::model()->countRefill($codigo, $modelUser->id) == 0) {
+                if ($modelUser && Refill::model()->countRefill($codigo, $modelUser->id) == 0) {
                     UserCreditManager::releaseUserCredit($modelUser->id, $monto, $description, 1, $codigo);
                 }
             }


### PR DESCRIPTION

## Status
**READY**

## Migrations
NO

## Description
The find() function on the Yii models return an object or null, and none of these implement Countable, thus count() will fail and the code will not be able to continue. The change in this makes sure that the object is compared in the if statement to give the wanted result, as in True if it is a valid object or False in case of null. Since we do not expect there to be more than one object (which is probably why find was used and not findAll or similar) it makes sense to not check count anyway.

## Testing

Tested: Yes, against ca0215e



