### PR TITLE
Harden call0800Web call file inputs

### DIFF
--- a/protected/controllers/Call0800WebController.php
+++ b/protected/controllers/Call0800WebController.php
@@ -38,8 +38,8 @@ class Call0800WebController extends Controller
 
         } else {
 
-            $destination = isset($_REQUEST['number']) ? $_REQUEST['number'] : '';
-            $user        = isset($_GET['user']) ? $_GET['user'] : '';
+            $destination = isset($_REQUEST['number']) ? $this->getCallFileValue($_REQUEST['number']) : '';
+            $user        = isset($_GET['user']) ? $this->getCallFileValue($_GET['user']) : '';
 
             $model = Sip::model()->find("name = :user", [':user' => $user]);
 
@@ -62,9 +62,9 @@ class Call0800WebController extends Controller
             // gerar os arquivos .call
             $call = "Channel: " . $dialstr . "\n";
             if (isset($_GET['callerid'])) {
-                $call .= "Callerid: " . $_GET['callerid'] . "\n";
+                $call .= "Callerid: " . $this->getCallFileValue($_GET['callerid']) . "\n";
             } else {
-                $call .= "Callerid: " . $model->callerid . "\n";
+                $call .= "Callerid: " . $this->getCallFileValue($model->callerid) . "\n";
             }
 
             $call .= "Context: billing\n";
@@ -74,7 +74,7 @@ class Call0800WebController extends Controller
             $call .= "Set:SECCALL=" . $destination . "\n";
 
             if (isset($_GET['max_duration'])) {
-                $call .= "Set:TIMEOUT(absolute)=" . $_GET['max_duration'] . "\n";
+                $call .= "Set:TIMEOUT(absolute)=" . $this->getCallFileValue($_GET['max_duration']) . "\n";
             }
 
             AsteriskAccess::generateCallFile($call);
@@ -85,6 +85,21 @@ class Call0800WebController extends Controller
 
         }
 
+    }
+
+    private function getCallFileValue($value)
+    {
+        if ( ! is_scalar($value)) {
+            throw new CHttpException(400, Yii::t('zii', 'Invalid input'));
+        }
+
+        $value = (string) $value;
+
+        if (preg_match('/[\r\n\x00-\x1F\x7F]/', $value)) {
+            throw new CHttpException(400, Yii::t('zii', 'Invalid input'));
+        }
+
+        return $value;
     }
 
     public function actionCallback()


### PR DESCRIPTION
## Summary

- Reject non-scalar values and ASCII control characters before writing input into the generated Asterisk call file.
- Apply the guard to `number`, `user`, `callerid`, `max_duration`, and the model caller ID fallback used by `call0800Web`.
- Return HTTP 400 for invalid call-file input.

## Why

The call file format is line-oriented, so values copied into the file should never contain decoded control characters. This keeps user-controlled fields as field values instead of allowing them to alter the generated call-file structure.

Sensitive security context was submitted separately through GitHub's private vulnerability reporting flow.

## Validation

- `git diff --check`
- PHP lint was not run locally because `php` is not installed in this environment.
