### PR TITLE
Fix EFI and PlacetoPay callback security

### DIFF
--- a/protected/controllers/EfiController.php
+++ b/protected/controllers/EfiController.php
@@ -13,7 +13,7 @@ class EfiController extends Controller
     public function actionIndex()
     {
         Yii::log(print_r($_REQUEST, true), 'error');
-        if (isset($_GET['id_user']) && isset($_GET['id']) && isset($_GET['amount']) && isset($_POST['notification'])) {
+        if (isset($_POST['notification'])) {
 
             $sql = "SELECT * FROM pkg_method_pay WHERE payment_method = 'EFI'";
             Yii::log(print_r($sql, true), 'error');
@@ -28,43 +28,13 @@ class EfiController extends Controller
                 'sandbox'       => false, // altere conforme o ambiente (true = desenvolvimento e false = producao)
             ];
 
-            $sql = "SELECT * FROM pkg_refill WHERE description LIKE :description";
-            Yii::log(print_r($sql, true), 'error');
-            $command = Yii::app()->db->createCommand($sql);
-            $command->bindValue(':description', "%" . $_POST['notification'] . "%", PDO::PARAM_STR);
-            $resultRefill = $command->queryAll();
-
-            if (! isset($resultRefill[0]['id'])) {
-                $sql = "INSERT INTO pkg_refill (id_user,credit,description,payment) VALUES
-                            (:id_user, :amount, :description , '0')";
-                Yii::log(print_r($sql, true), 'error');
-
-                $command = Yii::app()->db->createCommand($sql);
-                $command->bindValue(':id_user', $_GET['id_user'], PDO::PARAM_INT);
-                $command->bindValue(':amount', $_GET['amount'], PDO::PARAM_STR);
-                $command->bindValue(':description', 'Boleto gerado, Status:Aguardando ID:' . $_POST['notification'], PDO::PARAM_STR);
-                $resultRefill = $command->queryAll();
-
-                $id_refill = Yii::app()->db->lastInsertID;
-                sleep(1);
-                $sql = "SELECT * FROM pkg_refill WHERE id = :id_refill";
-                Yii::log(print_r($sql, true), 'error');
-                $command = Yii::app()->db->createCommand($sql);
-                $command->bindValue(':id_refill', $id_refill, PDO::PARAM_INT);
-                $resultRefill = $command->queryAll();
-            }
-
-            if ($resultRefill[0]['payment'] == 1) {
-                return;
-            }
-
             $token = $_POST['notification'];
 
             $params = [
                 'token' => $token,
             ];
             try {
-                $api                = new EfiPay($options);
+                $api                = $this->createEfiPay($options);
                 $chargeNotification = $api->getNotification($params, []);
                 // Para identificar o status atual da sua transação você deverá contar o número de situações contidas no array, pois a última posição guarda sempre o último status. Veja na um modelo de respostas na seção "Exemplos de respostas" abaixo.
 
@@ -81,6 +51,22 @@ class EfiController extends Controller
                 // Obtendo a String do status atual
                 $statusAtual = $status["current"];
                 Yii::log('statusAtual' . $statusAtual, 'error');
+
+                $sql = 'SELECT * FROM pkg_refill WHERE invoice_number = :charge_id LIMIT 1';
+                $command = Yii::app()->db->createCommand($sql);
+                $command->bindValue(':charge_id', (string) $charge_id, PDO::PARAM_STR);
+                $resultRefill = $command->queryRow();
+
+                if (! isset($resultRefill['id'])) {
+                    Yii::log('Rejected EFI callback for unknown charge ' . $charge_id, 'error');
+                    header('HTTP/1.1 404 Not Found');
+                    return;
+                }
+
+                if ($resultRefill['payment'] == 1) {
+                    return;
+                }
+
                 // Com estas informações, você poderá consultar sua base de dados e atualizar o status da transação especifica, uma vez que você possui o "charge_id" e a String do STATUS
                 switch ($statusAtual) {
                     case 'paid':
@@ -89,19 +75,19 @@ class EfiController extends Controller
                         $sql         = "UPDATE pkg_refill SET description= '" . $description . "', payment =1 WHERE id = :id";
                         Yii::log(print_r($sql, true), 'error');
                         $command = Yii::app()->db->createCommand($sql);
-                        $command->bindValue(':id', $resultRefill[0]['id'], PDO::PARAM_INT);
+                        $command->bindValue(':id', $resultRefill['id'], PDO::PARAM_INT);
                         $command->execute();
 
                         $sql = "UPDATE pkg_user SET credit= credit + :credit WHERE id = :id";
                         Yii::log(print_r($sql, true), 'error');
                         $command = Yii::app()->db->createCommand($sql);
-                        $command->bindValue(':id', $resultRefill[0]['id_user'], PDO::PARAM_INT);
-                        $command->bindValue(':credit', $resultRefill[0]['credit'], PDO::PARAM_STR);
+                        $command->bindValue(':id', $resultRefill['id_user'], PDO::PARAM_INT);
+                        $command->bindValue(':credit', $resultRefill['credit'], PDO::PARAM_STR);
                         $command->execute();
 
-                        $mail = new Mail(Mail::$TYPE_REFILL, $resultRefill[0]['id_user']);
-                        $mail->replaceInEmail(Mail::$ITEM_ID_KEY, $resultRefill[0]['id']);
-                        $mail->replaceInEmail(Mail::$ITEM_AMOUNT_KEY, $resultRefill[0]['credit']);
+                        $mail = new Mail(Mail::$TYPE_REFILL, $resultRefill['id_user']);
+                        $mail->replaceInEmail(Mail::$ITEM_ID_KEY, $resultRefill['id']);
+                        $mail->replaceInEmail(Mail::$ITEM_AMOUNT_KEY, $resultRefill['credit']);
                         $mail->replaceInEmail(Mail::$DESCRIPTION, $description);
                         $mail->send();
 
@@ -112,7 +98,7 @@ class EfiController extends Controller
                         $sql         = "UPDATE pkg_refill SET description= :description WHERE id = :id";
                         Yii::log(print_r($sql, true), 'error');
                         $command = Yii::app()->db->createCommand($sql);
-                        $command->bindValue(':id', $resultRefill[0]['id'], PDO::PARAM_INT);
+                        $command->bindValue(':id', $resultRefill['id'], PDO::PARAM_INT);
                         $command->bindValue(':description', $description, PDO::PARAM_STR);
                         $command->execute();
                         break;
@@ -122,7 +108,7 @@ class EfiController extends Controller
                         $sql         = "UPDATE pkg_refill SET description= :description WHERE id = :id";
                         Yii::log(print_r($sql, true), 'error');
                         $command = Yii::app()->db->createCommand($sql);
-                        $command->bindValue(':id', $resultRefill[0]['id'], PDO::PARAM_INT);
+                        $command->bindValue(':id', $resultRefill['id'], PDO::PARAM_INT);
                         $command->bindValue(':description', $description, PDO::PARAM_STR);
                         $command->execute();
                         break;
@@ -132,7 +118,7 @@ class EfiController extends Controller
                         $sql         = "UPDATE pkg_refill SET description= :description WHERE id = :id";
                         Yii::log(print_r($sql, true), 'error');
                         $command = Yii::app()->db->createCommand($sql);
-                        $command->bindValue(':id', $resultRefill[0]['id'], PDO::PARAM_INT);
+                        $command->bindValue(':id', $resultRefill['id'], PDO::PARAM_INT);
                         $command->bindValue(':description', $description, PDO::PARAM_STR);
                         $command->execute();
                         break;
@@ -140,10 +126,10 @@ class EfiController extends Controller
                         echo "Cobrança cancelada pelo vendedor ou pelo pagador.";
 
                         $description = "Boleto gerado, Status:Cobrança cancelada pelo vendedor ou pelo pagador, ID:" . $token;
-                        $sql         = "UPDATE pkg_refill SET description= :description WHERE id =" . $id;
+                        $sql         = "UPDATE pkg_refill SET description= :description WHERE id = :id";
                         Yii::log(print_r($sql, true), 'error');
                         $command = Yii::app()->db->createCommand($sql);
-                        $command->bindValue(':id', $resultRefill[0]['id'], PDO::PARAM_INT);
+                        $command->bindValue(':id', $resultRefill['id'], PDO::PARAM_INT);
                         $command->bindValue(':description', $description, PDO::PARAM_STR);
                         $command->execute();
                         break;
@@ -162,5 +148,10 @@ class EfiController extends Controller
                 print_r($e->getMessage());
             }
         }
+    }
+
+    protected function createEfiPay($options)
+    {
+        return new EfiPay($options);
     }
 }

--- a/protected/controllers/PlacetoPayController.php
+++ b/protected/controllers/PlacetoPayController.php
@@ -37,7 +37,7 @@ class PlacetoPayController extends Controller
 
         // --- 2) NOTIFICAÇÃO / CALLBACK VIA JSON (PlacetoPay -> servidor) ---
 
-        $rawBody = file_get_contents('php://input');
+        $rawBody = $this->getCallbackBody();
         $rest    = json_decode($rawBody, true);
 
         // Loga o corpo recebido para auditoria/debug
@@ -108,24 +108,49 @@ class PlacetoPayController extends Controller
 
             $description = 'Recarga PlaceToPay Aprobada. Referencia: ' . $safeReference;
 
-            // Exemplo de lógica específica por país
-            if ((int)$modelRefill->idUser->country === 57 && $modelRefill->credit > 0) {
-                $sql     = "INSERT INTO pkg_invoice (id_user) VALUES (:id_user)";
+            $transaction = Yii::app()->db->beginTransaction();
+
+            try {
+                $sql = 'UPDATE pkg_refill SET payment = 1, description = :description '
+                    . 'WHERE id = :id AND payment = 0';
+                $command = Yii::app()->db->createCommand($sql);
+                $command->bindValue(':description', $description, PDO::PARAM_STR);
+                $command->bindValue(':id', $modelRefill->id, PDO::PARAM_INT);
+
+                if ($command->execute() !== 1) {
+                    $transaction->rollBack();
+                    return;
+                }
+
+                // Exemplo de lógica específica por país
+                if ((int)$modelRefill->idUser->country === 57 && $modelRefill->credit > 0) {
+                    $sql     = "INSERT INTO pkg_invoice (id_user) VALUES (:id_user)";
+                    $command = Yii::app()->db->createCommand($sql);
+                    $command->bindValue(":id_user", $modelRefill->id_user, PDO::PARAM_INT);
+                    $command->execute();
+
+                    $sql = 'UPDATE pkg_refill SET invoice_number = :invoice_number WHERE id = :id';
+                    $command = Yii::app()->db->createCommand($sql);
+                    $command->bindValue(':invoice_number', Yii::app()->db->lastInsertID, PDO::PARAM_STR);
+                    $command->bindValue(':id', $modelRefill->id, PDO::PARAM_INT);
+                    $command->execute();
+                }
+
+                $sql     = "UPDATE pkg_user SET credit = credit + :credit WHERE id = :id_user";
                 $command = Yii::app()->db->createCommand($sql);
                 $command->bindValue(":id_user", $modelRefill->id_user, PDO::PARAM_INT);
+                $command->bindValue(":credit", $modelRefill->credit, PDO::PARAM_STR);
                 $command->execute();
-                $modelRefill->invoice_number = Yii::app()->db->lastInsertID;
+
+                $transaction->commit();
+            } catch (Exception $e) {
+                if ($transaction->active) {
+                    $transaction->rollBack();
+                }
+                Yii::log('PlacetoPay callback failed: ' . $e->getMessage(), 'error');
+                echo 'ERROR';
+                return;
             }
-
-            $modelRefill->payment     = 1;
-            $modelRefill->description = $description;
-            $modelRefill->save();
-
-            $sql     = "UPDATE pkg_user SET credit = credit + :credit WHERE id = :id_user";
-            $command = Yii::app()->db->createCommand($sql);
-            $command->bindValue(":id_user", $modelRefill->id_user, PDO::PARAM_INT);
-            $command->bindValue(":credit", $modelRefill->credit, PDO::PARAM_STR);
-            $command->execute();
 
             $mail = new Mail(Mail::$TYPE_REFILL, $modelRefill->id_user);
             $mail->replaceInEmail(Mail::$ITEM_ID_KEY, $modelRefill->id);
@@ -138,9 +163,16 @@ class PlacetoPayController extends Controller
 
             Yii::log($description, 'error');
 
-            $modelRefill->payment     = 0;
-            $modelRefill->description = $description;
-            $modelRefill->save();
+            $sql = 'UPDATE pkg_refill SET description = :description WHERE id = :id AND payment = 0';
+            $command = Yii::app()->db->createCommand($sql);
+            $command->bindValue(':description', $description, PDO::PARAM_STR);
+            $command->bindValue(':id', $modelRefill->id, PDO::PARAM_INT);
+            $command->execute();
         }
+    }
+
+    protected function getCallbackBody()
+    {
+        return file_get_contents('php://input');
     }
 }

--- a/protected/views/buyCredit/efi.php
+++ b/protected/views/buyCredit/efi.php
@@ -71,7 +71,7 @@ if (!isset($_GET['id'])) {
 
     $protocol = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on' ? 'https://' : 'http://';
 
-    $metadata = array('notification_url' => $protocol . $_SERVER['HTTP_HOST'] . '/mbilling/index.php/efi?id_user=' . $modelUser->id . '&id=' . time() . '&amount=' . $_GET['amount']);
+    $metadata = array('notification_url' => $protocol . $_SERVER['HTTP_HOST'] . '/mbilling/index.php/efi');
 
     $body = [
         'items'    => $items,
@@ -90,7 +90,17 @@ if (!isset($_GET['id'])) {
     }
 
     if (isset($charge['data']['charge_id'])) {
-        //echo "Processando Pagamento ID: ". $charge['data']['charge_id']." .....<br>";
+        $modelRefill                 = new Refill();
+        $modelRefill->id_user        = $modelUser->id;
+        $modelRefill->credit         = intval($amount) / 100;
+        $modelRefill->payment        = 0;
+        $modelRefill->invoice_number = (string) $charge['data']['charge_id'];
+        $modelRefill->description    = 'EFI charge pending, ID:' . $charge['data']['charge_id'];
+
+        if (! $modelRefill->save()) {
+            Yii::log('Unable to persist EFI charge ' . $charge['data']['charge_id'], 'error');
+            exit;
+        }
     } else {
         exit;
     }


### PR DESCRIPTION
## What changed

- bind EFI callbacks to a stored payment intent using the provider charge ID
- derive the EFI beneficiary and credited value from the stored intent instead of callback query parameters
- make PlacetoPay approval an atomic one-time payment transition
- prevent rejected callbacks from reopening an already paid refill

## Root cause

The EFI callback trusted beneficiary and amount parameters from its URL instead of associating the verified provider charge with a local payment intent. PlacetoPay accepted a valid signed callback repeatedly and credited the same refill on every approved replay.

## Validation

- PHP syntax checks passed for all changed files
- focused EFI tampered-beneficiary/value regression passed
- focused PlacetoPay replay regression passed
- APPROVED -> REJECTED -> APPROVED bypass regression passed
- git diff --check passed

The repository PHP build remains pending because the required sudo command needs an interactive password in the current environment.