### PR TITLE
Limit failed call event lookup by call time

### DIFF
--- a/CALL_FAILED_DIAGNOSTIC_CORRELATION.md
+++ b/CALL_FAILED_DIAGNOSTIC_CORRELATION.md
@@ -162,7 +162,11 @@ Fluxo proposto, sem mudança de schema:
 3. verificar a existência das tabelas Sentinel por metadados;
 4. buscar eventos com
    `WHERE uniqueid = :uniqueid AND id_server = :id_server
+   AND event_time BETWEEN :event_window_start AND :event_window_end
    ORDER BY event_time ASC, id ASC LIMIT :limit`;
+   a janela cobre do horário do INVITE ao horário persistido no CDR, com cinco
+   minutos de margem em cada lado; horário nunca é usado como correlação ou
+   fallback;
 5. usar `ix_uniqueid`; o plano verificado no piloto foi `ref`, estimativa de
    uma linha;
 6. obter saúde apenas da pequena
@@ -457,8 +461,8 @@ Implementado:
 - `POST index.php/callDiagnostic/cdrFailed`, exclusivo para administrador e
   com `cdrFailedId` como único dado de negócio aceito;
 - `FailedCallDiagnosticService`, determinístico, local e versionado;
-- consulta exata por `uniqueid + id_server`, usando `ix_uniqueid`, ordenada e
-  limitada;
+- consulta exata por `uniqueid + id_server`, usando `ix_uniqueid`, limitada à
+  janela temporal da chamada, ordenada e limitada;
 - estados de ausência, expiração, saúde da pipeline e truncamento;
 - catálogo explícito sem regra genérica para códigos `>=500`;
 - códigos internos 612–618 preservados como `internal_unknown`;

--- a/protected/components/FailedCallDiagnosticService.php
+++ b/protected/components/FailedCallDiagnosticService.php
@@ -12,6 +12,7 @@ class FailedCallDiagnosticService
     const CONTRACT = 'magnusbilling.call-diagnostic/v1';
     const CATALOG = 'magnusbilling.call-diagnostic-catalog/v1';
     const EVENT_LIMIT = 50;
+    const EVENT_WINDOW_MARGIN_SECONDS = 300;
 
     private $db;
     private $healthResolver;
@@ -64,7 +65,12 @@ class FailedCallDiagnosticService
             );
         }
 
-        $eventParams = [':uniqueid' => (string) $cdr['uniqueid']];
+        $eventWindow = $this->eventWindow($cdr);
+        $eventParams = [
+            ':uniqueid' => (string) $cdr['uniqueid'],
+            ':event_window_start' => $eventWindow['start'],
+            ':event_window_end' => $eventWindow['end'],
+        ];
         if ($cdr['id_server'] === null) {
             $serverCondition = 'e.id_server IS NULL';
         } else {
@@ -81,6 +87,8 @@ class FailedCallDiagnosticService
             LEFT JOIN pkg_servers s ON s.id=e.id_server
             WHERE e.uniqueid=:uniqueid
               AND " . $serverCondition . "
+              AND e.event_time BETWEEN :event_window_start
+                                   AND :event_window_end
             ORDER BY e.event_time ASC,e.id ASC
             LIMIT 51
             ",
@@ -291,6 +299,7 @@ class FailedCallDiagnosticService
                 ),
                 'catalog' => self::CATALOG,
                 'queryOrder' => ['event_time', 'id'],
+                'eventWindow' => $eventWindow,
             ],
         ];
     }
@@ -783,6 +792,43 @@ class FailedCallDiagnosticService
             'at' => $date->format('Y-m-d H:i:s'),
             'unixTimestamp' => $epoch,
             'source' => 'uniqueid_epoch',
+        ];
+    }
+
+    /**
+     * Bounds the indexed uniqueid lookup to the observed call interval.
+     * Time is never used as a fallback correlation key: uniqueid and server
+     * equality remain mandatory in the SQL query.
+     */
+    private function eventWindow(array $cdr)
+    {
+        $invite = $this->inviteTime(
+            (string) $cdr['uniqueid'],
+            (string) $cdr['starttime']
+        );
+        $inviteTimestamp = strtotime((string) $invite['at']);
+        $cdrTimestamp = strtotime((string) $cdr['starttime']);
+
+        if ($inviteTimestamp === false && $cdrTimestamp === false) {
+            $inviteTimestamp = $cdrTimestamp = 0;
+        } elseif ($inviteTimestamp === false) {
+            $inviteTimestamp = $cdrTimestamp;
+        } elseif ($cdrTimestamp === false) {
+            $cdrTimestamp = $inviteTimestamp;
+        }
+
+        return [
+            'start' => date(
+                'Y-m-d H:i:s',
+                min($inviteTimestamp, $cdrTimestamp)
+                    - self::EVENT_WINDOW_MARGIN_SECONDS
+            ),
+            'end' => date(
+                'Y-m-d H:i:s',
+                max($inviteTimestamp, $cdrTimestamp)
+                    + self::EVENT_WINDOW_MARGIN_SECONDS
+            ),
+            'marginSeconds' => self::EVENT_WINDOW_MARGIN_SECONDS,
         ];
     }
 


### PR DESCRIPTION
## O que mudou

- mantém `uniqueid + id_server` como correlação obrigatória;
- restringe a consulta dos eventos pelo intervalo temporal observado da chamada;
- inicia a janela cinco minutos antes do INVITE e encerra cinco minutos depois do horário persistido no CDR;
- mantém o índice `ix_uniqueid`, a ordem `event_time, id` e o limite de 50 eventos;
- expõe a janela aplicada nos detalhes técnicos do contrato;
- atualiza o relatório de correlação.

## Motivo

Embora o `uniqueid` indexado já seja seletivo, limitar também por `event_time` evita considerar dados distantes e reduz o trabalho residual em casos de colisão ou histórico anormal, sem usar horário como correlação silenciosa.

## Segurança da correlação

O horário é somente um filtro adicional. Um evento continua sendo aceito apenas quando possui o mesmo `uniqueid` e o mesmo `id_server` do CDR. Para MASTER, a condição existente `id_server IS NULL` permanece inalterada.

## Validação

- chamada `1785775900.3185`: janela calculada de `2026-08-03 16:46:40` até `2026-08-03 16:57:18`;
- fallback para `uniqueid` sem timestamp usa o horário do CDR com margem de cinco minutos;
- verificação estática das três condições SQL obrigatórias;
- `php -l` e `git diff --check`.

Não há mudança de schema, Magnus Sentinel, Asterisk ou formato de evento.
