### PR TITLE
Fix full PJSIP trunk names in Calls Online

### DIFF
--- a/protected/commands/CallChartCommand.php
+++ b/protected/commands/CallChartCommand.php
@@ -113,10 +113,16 @@ class CallChartCommand extends ConsoleCommand
 
                 $uniqueid    = null;
                 $trunk       = null;
-                if (preg_match('/^PJSIP\/([^-\s]+)/', $channel, $m)) {
+                if (preg_match('/^PJSIP\/(.+)-[0-9a-f]+(?:;[12])?$/i', $channel, $m)) {
                     $sip_account = $m[1];
                 } else {
                     $sip_account = '';
+                }
+
+                // Browser WebRTC endpoints use the <sip-account>-web name.
+                // Resolve them to the originating Magnus SIP account for Calls Online.
+                if (substr($sip_account, -4) === '-web') {
+                    $sip_account = substr($sip_account, 0, -4);
                 }
                 $ndiscado    = trim($call[2]);
 
@@ -127,7 +133,7 @@ class CallChartCommand extends ConsoleCommand
 
 
                 $chan = trim($call[9] ?? '');
-                if (preg_match('#^[^/]+/([^-]+)-#', $chan, $m)) {
+                if (preg_match('#^[^/]+/(.+)-[0-9a-f]+(?:;[12])?$#i', $chan, $m)) {
 
                     $des_chan    = $trunk =  $m[1];
                 } else {

--- a/protected/commands/CallChartStatusCommand.php
+++ b/protected/commands/CallChartStatusCommand.php
@@ -271,6 +271,13 @@ class CallChartStatusCommand extends ConsoleCommand
 
     private function endpoint(array $call)
     {
+        // Asterisk can expose a shortened CHANNEL(endpoint) value (for example
+        // "ProviderA") even when the PJSIP channel contains the full trunk name.
+        $channel = $this->field($call, 'Channel');
+        if (preg_match('#^(?:PJSIP|SIP|IAX2?)/(.+)-[0-9a-f]+(?:;[12])?$#i', $channel, $match)) {
+            return $match[1];
+        }
+
         $variable = $this->field($call, 'Variable');
         if (preg_match('/^CHANNEL\(endpoint\)=(.*)$/', $variable, $match)) {
             $endpoint = trim($match[1]);
@@ -278,10 +285,7 @@ class CallChartStatusCommand extends ConsoleCommand
                 return $endpoint;
             }
         }
-        $channel = $this->field($call, 'Channel');
-        return preg_match('#^(?:PJSIP|SIP|IAX2?)/(.+)-[0-9a-f]+(?:;[12])?$#i', $channel, $match)
-            ? $match[1]
-            : '';
+        return '';
     }
 
     private function dialedNumber(array $call)


### PR DESCRIPTION
## Summary

Calls Online currently prefers the `CHANNEL(endpoint)` AMI variable. On some PJSIP calls, Asterisk provides a shortened provider label there (for example, `ProviderA`) while the channel name contains the full configured endpoint (for example, `PJSIP/ProviderA-Primary-...`).

This change parses the full endpoint from the channel name first, then falls back to `CHANNEL(endpoint)` only when the channel name cannot be parsed.

## Impact

This affects the Calls Online display only. It does not change call routing, billing, trunk selection, or active calls.
