### PR TITLE
Fix full PJSIP trunk names in Calls Online

### DIFF
--- a/protected/commands/CallChartCommand.php
+++ b/protected/commands/CallChartCommand.php
@@ -127,7 +127,9 @@ class CallChartCommand extends ConsoleCommand
 
 
                 $chan = trim($call[9] ?? '');
-                if (preg_match('#^[^/]+/([^-]+)-#', $chan, $m)) {
+                // The final token is Asterisk's hexadecimal channel suffix.
+                // Keep dashes that are part of the configured PJSIP endpoint.
+                if (preg_match('#^[^/]+/(.+)-[0-9a-f]+(?:;[12])?$#i', $chan, $m)) {
 
                     $des_chan    = $trunk =  $m[1];
                 } else {


### PR DESCRIPTION
Fixes #748

The channel suffix is parsed from the final hexadecimal Asterisk token, preserving dashes in configured PJSIP endpoint names.