### PR TITLE
Replace stale dynamic PJSIP contacts

### DIFF
--- a/protected/components/AsteriskAccess.php
+++ b/protected/components/AsteriskAccess.php
@@ -1154,6 +1154,12 @@ class AsteriskAccess
                     if (isset($sip->max_contacts) && strlen($sip->max_contacts) > 0) {
                         $line .= "max_contacts=" . trim($sip->max_contacts) . "\n";
                     }
+                    if ($host == 'dynamic') {
+                        // Replace stale registrations without changing the
+                        // account's configured maximum number of contacts.
+                        $line .= "remove_existing=yes\n";
+                        $line .= "remove_unavailable=yes\n";
+                    }
                     if ($host != 'dynamic') {
 
                         // peer por IP


### PR DESCRIPTION
Fixes #750

For dynamic PJSIP AORs, replace stale or unavailable contacts on a valid new registration without changing the configured `max_contacts` value.