### PR TITLE
Refresh Sentinel after MagnusBilling updates

### DIFF
--- a/protected/commands/updateCommand.sh
+++ b/protected/commands/updateCommand.sh
@@ -84,3 +84,12 @@ if ! php /var/www/html/mbilling/cron.php UpdateMysql; then
     exit 1
 fi
 
+## Refresh optional Magnus Sentinel state only after a successful update.
+SENTINEL_POST_UPDATE=/opt/magnus-sentinel/refresh-after-mbilling-update
+if [ -x "$SENTINEL_POST_UPDATE" ]; then
+    echo "Refreshing Magnus Sentinel after the MagnusBilling update."
+    if ! "$SENTINEL_POST_UPDATE"; then
+        echo "WARNING: MagnusBilling was updated, but Magnus Sentinel refresh failed." >&2
+        echo "Run $SENTINEL_POST_UPDATE after correcting the reported error." >&2
+    fi
+fi


### PR DESCRIPTION
## Problem

A successful MagnusBilling update can leave the installed Sentinel integrity reference on the previous release. Client-specific `update3.sh` hooks are not an appropriate product integration point.

## Solution

After the database migration succeeds, `updateCommand.sh` calls `/opt/magnus-sentinel/refresh-after-mbilling-update` only when that optional executable exists. The Sentinel package owns manifest generation, validation, integrity collection, and analysis.

## Risk and compatibility

Systems without Sentinel are unchanged. Sentinel refresh failure is reported as a warning and does not roll back an already completed MagnusBilling update. No database, API, billing, PJSIP, or Asterisk behavior changes. Sentinel itself only installs the contract when the C `app_mbilling.so` module is validated.

## Verification

- `bash -n protected/commands/updateCommand.sh`
- compared with the current production script; the optional nine-line block is the only change
- companion Sentinel focused suite: 29 tests passed

## Deployment and rollback

Deploy with the companion Magnus Sentinel PR. Rollback by reverting this commit; absence of the executable is already a no-op.

## Checklist

- [x] I removed secrets, customer data, and unrelated changes.
- [x] I added or updated tests for changed behavior in the companion Sentinel repository.
- [x] No translations are required for this command-line integration.
- [x] Documentation is maintained in the companion Sentinel repository.
- [x] I described the available verification.
- [x] I reviewed the contribution and security policies.