### PR TITLE
Fix inbound PJSIP auth for static trunks with insecure=invite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ migration instructions remain authoritative for deployment.
 
 ## Unreleased
 
+### Fixed
+
+- Honor `insecure=invite` (including `port,invite`) for static PJSIP provider
+  trunks with credentials: identify inbound traffic only by the configured
+  provider IP match instead of issuing a SIP authentication challenge. Preserve
+  outbound authentication and registration, and keep dynamic trunks authenticated.
+
 ### Documentation
 
 - Reworked the repository introduction, installation, migration, development,

--- a/protected/components/AsteriskAccess.php
+++ b/protected/components/AsteriskAccess.php
@@ -376,7 +376,17 @@ class AsteriskAccess
                     $line .= "from_domain = " . $data['fromdomain'] . "\n";
                 }
                 if (strlen($data['user']) && strlen($data['secret'])) {
-                    $line .= "auth = auth_reg_" . $data[$head_field] . '_' . $data['user'] . '_' . $data['host'] . "\n";
+                    // Static providers with insecure=invite authenticate inbound
+                    // calls by their identify IP match, not by SIP credentials.
+                    // Dynamic gateways must still authenticate their registrations.
+                    $insecureOptions = array_map('trim', explode(',', strtolower((string) ($data['insecure'] ?? ''))));
+                    $trustProviderIp = $head_field === 'trunkcode' && ! $isDynamicHost
+                        && in_array('invite', $insecureOptions, true);
+                    if ($trustProviderIp) {
+                        $line .= "identify_by = ip\n";
+                    } else {
+                        $line .= "auth = auth_reg_" . $data[$head_field] . '_' . $data['user'] . '_' . $data['host'] . "\n";
+                    }
                     $line .= "outbound_auth = auth_reg_" . $data[$head_field] . '_' . $data['user'] . '_' . $data['host'] . "\n";
                 }
 

--- a/protected/tests/unit/PjsipInsecureInviteTest.php
+++ b/protected/tests/unit/PjsipInsecureInviteTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * Standalone regression test: php protected/tests/unit/PjsipInsecureInviteTest.php
+ * Exercises the real generator and validator without a database or AMI connection.
+ */
+class Util
+{
+    public static function getColumnsFromModel($model)
+    {
+        return $model;
+    }
+}
+
+class InsecureInviteTestDb
+{
+    public function createCommand($sql)
+    {
+        return $this;
+    }
+
+    public function queryAll()
+    {
+        return [];
+    }
+}
+
+class Yii
+{
+    public static function app()
+    {
+        return (object) ['db' => new InsecureInviteTestDb()];
+    }
+}
+
+require_once __DIR__ . '/../../components/AsteriskConfigValue.php';
+require_once __DIR__ . '/../../components/AsteriskAccess.php';
+
+function checkInsecureInvite($condition, $message)
+{
+    if (! $condition) {
+        throw new RuntimeException($message);
+    }
+}
+
+$generator = (new ReflectionClass('AsteriskAccess'))->newInstanceWithoutConstructor();
+$fixture = [
+    'trunkcode' => 'TEST_PROVIDER', 'name' => 'TEST_PROVIDER',
+    'user' => 'TEST_USER', 'secret' => 'test-only-password',
+    'host' => '192.0.2.10',
+    'register_string' => 'TEST_USER:test-only-password@192.0.2.10',
+    'port' => '5060', 'qualify' => 'yes', 'context' => 'billing',
+    'allow' => 'alaw,ulaw', 'directmedia' => 'no', 'language' => '',
+    'fromuser' => 'TEST_USER', 'fromdomain' => '192.0.2.10',
+];
+
+// Label, overrides, head field, expected IP-only identification.
+$cases = [
+    ['invite', ['insecure' => 'invite'], 'trunkcode', true],
+    ['port and invite', ['insecure' => 'port,invite'], 'trunkcode', true],
+    ['case and whitespace', ['insecure' => ' PORT, INVITE '], 'trunkcode', true],
+    ['reversed options', ['insecure' => 'invite,port'], 'trunkcode', true],
+    ['hostname', ['insecure' => 'invite', 'host' => 'carrier.example.com'], 'trunkcode', true],
+    ['no outbound registration', ['insecure' => 'invite', 'register_string' => ''], 'trunkcode', true],
+    ['port only', ['insecure' => 'port'], 'trunkcode', false],
+    ['empty insecure', ['insecure' => ''], 'trunkcode', false],
+    ['missing insecure', [], 'trunkcode', false],
+    ['substring is not an option', ['insecure' => 'notinvite'], 'trunkcode', false],
+    ['dynamic invite', ['insecure' => 'invite', 'host' => 'dynamic'], 'trunkcode', false],
+    ['dynamic combined', ['insecure' => 'port,invite', 'host' => ' Dynamic '], 'trunkcode', false],
+    ['non-trunk endpoint', ['insecure' => 'invite'], 'name', false],
+    ['no credentials', ['insecure' => 'invite', 'secret' => '', 'register_string' => ''], 'trunkcode', false],
+];
+
+$failures = [];
+foreach ($cases as [$label, $overrides, $headField, $trustProviderIp]) {
+    $row = array_merge($fixture, $overrides);
+    // Avoid pjsip/iax in the output path: those names trigger a live reload.
+    $file = tempnam(sys_get_temp_dir(), 'trunk-auth-test-');
+    try {
+        checkInsecureInvite($file !== false, 'cannot create temporary file');
+        checkInsecureInvite(! preg_match('/pjsip|iax/', $file), 'unsafe temporary directory');
+        $generator->writeAsteriskFile([$row], $file, $headField);
+        $config = file_get_contents($file);
+        $dynamic = strtolower(trim($row['host'])) === 'dynamic';
+        $hasCredentials = strlen($row['user']) && strlen($row['secret']);
+        $authName = 'auth_reg_' . $row[$headField] . '_' . $row['user'] . '_' . $row['host'];
+        $endpointCount = 0;
+        $registrationCount = 0;
+
+        foreach (preg_split('/^\[[^\r\n]+\]\r?\n/m', $config) as $section) {
+            if (strpos($section, "type = endpoint\n") === 0) {
+                $endpointCount++;
+                checkInsecureInvite(
+                    (bool) preg_match('/^auth = /m', $section) === ($hasCredentials && ! $trustProviderIp),
+                    'unexpected inbound authentication'
+                );
+                checkInsecureInvite(
+                    (strpos($section, 'outbound_auth = ' . $authName . "\n") !== false) === (bool) $hasCredentials,
+                    'outbound endpoint authentication changed'
+                );
+                checkInsecureInvite(
+                    (bool) preg_match('/^identify_by = ip$/m', $section) === $trustProviderIp,
+                    'unexpected endpoint identification method'
+                );
+            } elseif (strpos($section, "type = registration\n") === 0) {
+                $registrationCount++;
+                checkInsecureInvite(strpos($section, 'outbound_auth = ' . $authName . "\n") !== false,
+                    'outbound registration authentication changed');
+            }
+        }
+
+        checkInsecureInvite($endpointCount === ($dynamic ? 2 : 1), 'endpoint or dynamic alias missing');
+        checkInsecureInvite($registrationCount === ((! $dynamic && strlen($row['register_string'])) ? 1 : 0),
+            'outbound registration changed');
+        if ($trustProviderIp) {
+            checkInsecureInvite(strpos($config, "type = identify\nendpoint = TEST_PROVIDER\nmatch = " . $row['host'] . "\n") !== false,
+                'IP-only endpoint must retain its provider match');
+        }
+        if ($hasCredentials) {
+            checkInsecureInvite(strpos($config, '[' . $authName . "]\ntype = auth\nusername = TEST_USER\npassword = test-only-password\n") !== false,
+                'outbound credentials changed');
+        }
+    } catch (Throwable $error) {
+        $failures[] = $label . ': ' . $error->getMessage();
+    } finally {
+        if ($file !== false) {
+            unlink($file);
+        }
+    }
+}
+
+if ($failures) {
+    fwrite(STDERR, implode("\n", $failures) . "\n");
+    exit(1);
+}
+echo 'PASS: ' . count($cases) . " PJSIP inbound-auth regression cases\n";


### PR DESCRIPTION
## Problem

Static provider trunks can require credentials for outbound REGISTER and INVITE
while accepting inbound calls by source IP. MagnusBilling exposes `insecure`
with the `invite` / `port,invite` options, but the PJSIP generator currently
attaches inbound `auth` whenever the trunk has a username and password,
regardless of that setting.

As a result, an otherwise registered provider trunk can receive repeated
`401 Unauthorized` responses to incoming INVITEs even after the operator sets
`insecure=invite`. Editing the generated configuration is not persistent.

## Solution

- Honor the exact comma-separated `invite` option for static `trunkcode` records
  with credentials (case-insensitive and whitespace-tolerant).
- Omit the endpoint's inbound `auth` and explicitly set `identify_by = ip`,
  retaining the existing `identify` / `match` section. The endpoint must not
  become selectable just by a matching SIP username when inbound auth is absent.
- Preserve the auth object, endpoint `outbound_auth`, and outbound registration.
- Keep dynamic gateways, non-trunk records, and trunks without the exact
  `invite` option on their existing authentication behavior.
- Add a standalone regression test using the real generator and value validator,
  with synthetic fixtures and no database, AMI connection, or service reload.

This follows the separation between provider IP identification and outbound
authentication in the [Asterisk PJSIP configuration examples](https://docs.asterisk.org/Configuration/Channel-Drivers/SIP/Configuring-res_pjsip/res_pjsip-Configuration-Examples/).

## Risk and compatibility

- Intended behavior change: static trunks explicitly configured with
  `insecure=invite` trust their configured provider IP match for incoming requests.
  Operators must verify that this match contains only trusted provider sources.
- IP endpoint identification must be available in Asterisk. This change does not
  add provider addresses, alter firewall rules, or enable anonymous calling.
- Dynamic trunk REGISTER authentication and outbound credentials remain intact.
- No database migration, billing/rating, API, translation, or installer changes.
- This does not implement any additional `insecure=port` semantics, change
  credential-free trunks, or address other existing host parsing behavior.

## Verification

Executed locally with PHP 8.4.24:

```sh
php -l protected/components/AsteriskAccess.php
php -l protected/tests/unit/PjsipInsecureInviteTest.php
php -d error_reporting=E_ALL protected/tests/unit/PjsipInsecureInviteTest.php
git diff --cached --check
```

Result: **14 passing cases**. The same test against the unmodified generator
fails the six static-provider cases that explicitly request `invite`.
Coverage includes combined/reordered options, case/whitespace, missing/empty
options, non-matching substrings, provider hostname, no outbound registration,
dynamic endpoint aliases, non-trunk records, and missing credentials. It checks
both endpoint and registration outbound auth and the retained IP match.

Earlier runtime validation of the same generator change on Asterisk 20.9.2
observed an inbound carrier INVITE receiving `100 Trying` and `200 OK` without a
`401` challenge, while outbound registration remained `Registered`. No customer
data or packet captures are included. This is signaling evidence, not a claim
of exhaustive media or interoperability testing.

Additional isolated Asterisk validation recommended before release (not run in
this local PR workspace):

1. Generate/reload a static test trunk with credentials, a controlled provider
   source, and `insecure=port,invite`; verify IP-only identification, no inbound
   auth, and unchanged outbound registration/auth.
2. Send an INVITE from that provider and verify the test DID route is reached
   without a digest challenge; check two-way audio and the resulting CDR.
3. Send an INVITE from a different source using the same From username; verify
   it cannot select this trusted endpoint.
4. Remove `invite` and confirm inbound authentication is required again.
5. Test a dynamic gateway configured with `invite`: unauthenticated REGISTER
   must still be challenged and valid credentials must register successfully.

## Deployment and rollback

Back up the application generator and current generated PJSIP configuration.
Review the provider host/IP matches, deploy the change, and regenerate/reload
the trunk configuration through the normal MagnusBilling workflow. Merely
updating the PHP source does not rewrite an existing generated file.

To roll back, restore the previous generator and regenerate/reload, or restore
the backed-up generated configuration and reload PJSIP as part of the rollback.
There is no schema/data migration and no Asterisk restart requirement.

## Checklist

- [x] I removed secrets, customer data, and unrelated changes.
- [x] I added or updated tests for changed behavior.
- [x] I added translations for new user-facing text. (Not applicable: none added.)
- [x] I updated documentation and the changelog where appropriate.
- [x] I described tests that were not available in my environment.
- [x] I reviewed the contribution and security policies.
